### PR TITLE
Allow pre-split of training and validation data CSVs

### DIFF
--- a/.azure-pipelines/steps.yml
+++ b/.azure-pipelines/steps.yml
@@ -6,5 +6,8 @@ steps:
     conda install -c sdvillal openslide -y 
     conda install -c conda-forge libvips -y
     pip install -e .
-    pytest
-  displayName: 'Install dependencies and run tests'
+  displayName: 'Install dependencies'
+
+# - script: |
+#     pytest
+#   displayName: 'Run Tests'

--- a/.azure-pipelines/steps.yml
+++ b/.azure-pipelines/steps.yml
@@ -6,8 +6,5 @@ steps:
     conda install -c sdvillal openslide -y 
     conda install -c conda-forge libvips -y
     pip install -e .
-  displayName: 'Install dependencies'
-
-- script: |
     pytest
-  displayName: 'Run Tests'
+  displayName: 'Install dependencies and run tests'

--- a/.azure-pipelines/steps.yml
+++ b/.azure-pipelines/steps.yml
@@ -1,12 +1,13 @@
 steps:
 - script: |
-    conda create -p ./venv python=3.6.5 -y
+    conda create -p ./venv python=3.6 -y
     source activate ./venv
     conda install requests pytorch torchvision torchaudio cpuonly -c pytorch -y
     conda install -c sdvillal openslide -y 
+    conda install -c conda-forge libvips -y
     pip install -e .
   displayName: 'Install dependencies'
 
-# - script: |
-#     pytest
-#   displayName: 'Run Tests'
+- script: |
+    pytest
+  displayName: 'Run Tests'

--- a/GANDLF/inference_loop.py
+++ b/GANDLF/inference_loop.py
@@ -176,7 +176,7 @@ if os.name != 'nt':
         #test_csv = parameters['test_csv']
 
         # Defining our model here according to parameters mentioned in the configuration file
-        print("Number of dims      : ", parameters['model']['dimension'])
+        print("Number of dims     : ", parameters['model']['dimension'])
         if 'n_channels' in parameters['model']:
             print("Number of channels : ", parameters['model']['n_channels'])
         print("Number of classes  : ", n_classList)

--- a/GANDLF/training_loop.py
+++ b/GANDLF/training_loop.py
@@ -67,7 +67,7 @@ def trainingLoop(trainingDataFromPickle, validationDataFromPickle, headers, devi
         n_channels = parameters['model']['n_channels']
 
     # Defining our model here according to parameters mentioned in the configuration file
-    print("Number of dims      : ", parameters['model']['dimension'])
+    print("Number of dims     : ", parameters['model']['dimension'])
     if 'n_channels' in parameters['model']:
         print("Number of channels : ", parameters['model']['n_channels'])
     

--- a/GANDLF/training_manager.py
+++ b/GANDLF/training_manager.py
@@ -165,3 +165,8 @@ def TrainingManager(dataframe, headers, outputDir, parameters, device, reset_pre
         if singleFoldTesting:
             break
         currentTestingFold = currentTestingFold + 1 # increment the fold
+
+# This function takes in 2 dataframes, one for training and another for validation data, with some other parameters and returns the dataloader
+def TrainingManager(dataframe_train, dataframe_validation, headers, outputDir, parameters, device, reset_prev):
+    trainingLoop(trainingDataFromPickle=dataframe_train, validationDataFromPickle=dataframe_validation, headers = headers, 
+                outputDir=outputDir, device=device, parameters=parameters, testingDataFromPickle=None)

--- a/GANDLF/training_manager.py
+++ b/GANDLF/training_manager.py
@@ -175,7 +175,7 @@ def TrainingManager(dataframe, headers, outputDir, parameters, device, reset_pre
         currentTestingFold = currentTestingFold + 1 # increment the fold
 
 
-def TrainingManager(dataframe_train, dataframe_validation, headers, outputDir, parameters, device, reset_prev):
+def TrainingManager_split(dataframe_train, dataframe_validation, headers, outputDir, parameters, device, reset_prev):
     '''
     This is the training manager that ties all the training functionality together
 

--- a/GANDLF/training_manager.py
+++ b/GANDLF/training_manager.py
@@ -1,4 +1,3 @@
-
 import pandas as pd
 import os, sys, pickle, subprocess
 from sklearn.model_selection import KFold
@@ -7,8 +6,17 @@ from pathlib import Path
 # from GANDLF.data.ImagesFromDataFrame import ImagesFromDataFrame
 from GANDLF.training_loop import trainingLoop
 
-# This function takes in a dataframe, with some other parameters and returns the dataloader
 def TrainingManager(dataframe, headers, outputDir, parameters, device, reset_prev):
+    '''
+    This is the training manager that ties all the training functionality together
+
+    dataframe = full data from CSV
+    headers = pre-sorted CSV headers
+    outputDir = the main output directory
+    parameters = parameters read from YAML
+    device = self-explanatory
+    reset_prev = whether the previous run in the same output directory is used or not
+    '''
 
     # check for single fold training
     singleFoldValidation = False
@@ -166,7 +174,25 @@ def TrainingManager(dataframe, headers, outputDir, parameters, device, reset_pre
             break
         currentTestingFold = currentTestingFold + 1 # increment the fold
 
-# This function takes in 2 dataframes, one for training and another for validation data, with some other parameters and returns the dataloader
+
 def TrainingManager(dataframe_train, dataframe_validation, headers, outputDir, parameters, device, reset_prev):
+    '''
+    This is the training manager that ties all the training functionality together
+
+    dataframe_train = training data from CSV
+    dataframe_validation = validation data from CSV
+    headers = pre-sorted CSV headers
+    outputDir = the main output directory
+    parameters = parameters read from YAML
+    device = self-explanatory
+    reset_prev = whether the previous run in the same output directory is used or not
+    '''
+    currentModelConfigPickle = os.path.join(outputDir, 'parameters.pkl')
+    if (not os.path.exists(currentModelConfigPickle)) or reset_prev:
+        with open(currentModelConfigPickle, 'wb') as handle:
+            pickle.dump(parameters, handle, protocol=pickle.HIGHEST_PROTOCOL)
+    else:
+        print('Using previously saved parameter file', currentModelConfigPickle, flush=True)
+        parameters = pickle.load(open(currentModelConfigPickle,"rb"))
     trainingLoop(trainingDataFromPickle=dataframe_train, validationDataFromPickle=dataframe_validation, headers = headers, 
                 outputDir=outputDir, device=device, parameters=parameters, testingDataFromPickle=None)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 ## 0.0.7
 
+- Pre-split training/validation data can now be provided
+## 0.0.7
+
 - New modality switch added for rad/path
 - Class list can now be defined as a range
 - Added option to train and infer on fused labels

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
-## 0.0.7
+## 0.0.8
 
 - Pre-split training/validation data can now be provided
+
 ## 0.0.7
 
 - New modality switch added for rad/path

--- a/gandlf_run
+++ b/gandlf_run
@@ -14,7 +14,7 @@ from pathlib import Path
 import pkg_resources
 from datetime import date
 
-from GANDLF.training_manager import TrainingManager
+from GANDLF.training_manager import *
 from GANDLF.inference_manager import InferenceManager 
 from GANDLF.parseConfig import parseConfig
 
@@ -22,7 +22,7 @@ def main():
     copyrightMessage = 'Contact: software@cbica.upenn.edu\n\n' + 'This program is NOT FDA/CE approved and NOT intended for clinical use.\nCopyright (c) ' + str(date.today().year) + ' University of Pennsylvania. All rights reserved.' 
     parser = argparse.ArgumentParser(prog='GANDLF', formatter_class=argparse.RawTextHelpFormatter, description = "Image Semantic Segmentation and Regression using Deep Learning.\n\n" + copyrightMessage)
     parser.add_argument('-config', type=str, help = 'The configuration file (contains all the information related to the training/inference session), this is read from \'modelDir\' during inference', required=True)
-    parser.add_argument('-data', type=str, help = 'Data csv file that is used for training/inference', required=True)
+    parser.add_argument('-data', type=str, help = 'Data csv file that is used for training/inference; can also take a comma-separate training-validatation pre-split CSV', required=True)
     parser.add_argument('-output', type=str, help = 'Output directory to save intermediate files and model weights', required=True)
     parser.add_argument('-train', default=1, type=int, help = '1 == training and 0 == inference; for 0, there needs to be a compatible model saved in \'-modelDir\'', required=True)
     parser.add_argument('-modelDir', type=str, help = 'The pre-trained model directory that is used for inference, needs to contain the configuration', required=False)
@@ -52,7 +52,21 @@ def main():
         Path(model_path).mkdir(parents=True, exist_ok=True)
 
     # parse training CSV
-    data_full, headers = parseTrainingCSV(file_data_full)
+    if ',' in file_data_full:
+        # training and validation pre-split
+        test = 1
+        data_full = None
+        both_csvs = file_data_full.split(',')
+        data_train, headers_train = parseTrainingCSV(both_csvs[0])
+        data_validation, headers_validation = parseTrainingCSV(both_csvs[1])
+
+        if headers_train != headers_validation:
+            sys.exit('The training and validation CSVs do not have the same header information.')
+        
+        # if we are here, it is assumed that the user wants to do training
+        TrainingManager(dataframe_train=data_train, dataframe_validation=data_validation, headers = headers_train, outputDir=model_path, parameters=parameters, device=device, reset_prev = reset_prev)
+    else:
+        data_full, headers = parseTrainingCSV(file_data_full)
     
     if mode != 0: # training mode
         TrainingManager(dataframe=data_full, headers = headers, outputDir=model_path, parameters=parameters, device=device, reset_prev = reset_prev)

--- a/samples/sample_training.yaml
+++ b/samples/sample_training.yaml
@@ -1,8 +1,8 @@
 # affix version
 version:
   {
-    minimum: 0.0.7,
-    maximum: 0.0.7 # this should NOT be made a variable, but should be tested after every tag is created
+    minimum: 0.0.8,
+    maximum: 0.0.8 # this should NOT be made a variable, but should be tested after every tag is created
   }
 # Choose the model parameters here
 model:

--- a/samples/sample_training_brats.yaml
+++ b/samples/sample_training_brats.yaml
@@ -1,8 +1,8 @@
 # affix version
 version:
   {
-    minimum: 0.0.7,
-    maximum: 0.0.7 # this should NOT be made a variable, but should be tested after every tag is created
+    minimum: 0.0.8,
+    maximum: 0.0.8 # this should NOT be made a variable, but should be tested after every tag is created
   }
 # Choose the model parameters here
 model:

--- a/samples/sample_training_histopathology.yaml
+++ b/samples/sample_training_histopathology.yaml
@@ -1,8 +1,8 @@
 # affix version
 version:
   {
-    minimum: 0.0.7,
-    maximum: 0.0.7 # this should NOT be made a variable, but should be tested after every tag is created
+    minimum: 0.0.8,
+    maximum: 0.0.8 # this should NOT be made a variable, but should be tested after every tag is created
   }
 # Choose the model parameters here
 model:

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ requirements = [
 
 setup(
   name='GANDLF',
-  version='0.0.7-dev', # NR: non-release; this should be changed when tagging
+  version='0.0.8-dev', # NR: non-release; this should be changed when tagging
   author="Ujjwal Baid, Megh Bhalerao, Caleb Grenko, Sarthak Pati, Siddhesh Thakur", # alphabetical order
   author_email='software@cbica.upenn.edu',
   python_requires='>=3.6',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ requirements = [
   'matplotlib',
   'requests==2.25.0',
   'pyvips',
-  'torchviz',
   'pytest',
   'pytest-azurepipelines'
 ]

--- a/testing/test_full.py
+++ b/testing/test_full.py
@@ -119,7 +119,7 @@ def test_train_segmentation_rad_3d():
 
 def test_regression_rad_2d():
   application_data = '2d_rad_segmentation'
-  parameters = parseConfig(inputDir + '/' + application_data + '/sample_training_regression.yaml')
+  parameters = parseConfig(inputDir + '/' + application_data + '/sample_training_regression.yaml', version_check = False)
   training_data, headers = parseTrainingCSV(inputDir + '/train_2d_rad_regression.csv')
   for model in all_models_regression:
     parameters['model']['architecture'] = model 
@@ -131,7 +131,7 @@ def test_regression_rad_2d():
 
 def test_regression_rad_3d():
   application_data = '3d_rad_segmentation'
-  parameters = parseConfig(inputDir + '/' + application_data + '/sample_training_regression.yaml')
+  parameters = parseConfig(inputDir + '/' + application_data + '/sample_training_regression.yaml', version_check = False)
   training_data, headers = parseTrainingCSV(inputDir + '/train_3d_rad_regression.csv')
   for model in all_models_regression:
     parameters['model']['architecture'] = model 
@@ -143,7 +143,7 @@ def test_regression_rad_3d():
 
 def test_classification_rad_2d():
   application_data = '2d_rad_segmentation'
-  parameters = parseConfig(inputDir + '/' + application_data + '/sample_training_classification.yaml')
+  parameters = parseConfig(inputDir + '/' + application_data + '/sample_training_classification.yaml', version_check = False)
   training_data, headers = parseTrainingCSV(inputDir + '/train_2d_rad_classification.csv')
   shutil.rmtree(outputDir) # overwrite previous results
   Path(outputDir).mkdir(parents=True, exist_ok=True)
@@ -157,7 +157,7 @@ def test_classification_rad_2d():
 
 def test_classification_rad_3d():
   application_data = '3d_rad_segmentation'
-  parameters = parseConfig(inputDir + '/' + application_data + '/sample_training_classification.yaml')
+  parameters = parseConfig(inputDir + '/' + application_data + '/sample_training_classification.yaml', version_check = False)
   training_data, headers = parseTrainingCSV(inputDir + '/train_3d_rad_classification.csv')
   for model in all_models_regression:
     parameters['model']['architecture'] = model 

--- a/testing/test_full.py
+++ b/testing/test_full.py
@@ -1,7 +1,7 @@
 import math
 import sys
 from pathlib import Path
-import requests, zipfile, io, os, csv, random, copy
+import requests, zipfile, io, os, csv, random, copy, shutil
 
 from GANDLF.utils import *
 from GANDLF.parseConfig import parseConfig
@@ -97,9 +97,9 @@ def test_train_segmentation_rad_2d():
   training_data, headers = parseTrainingCSV(inputDir + '/train_' + application_data + '.csv')
   for model in all_models_segmentation:
     parameters['model']['architecture'] = model 
-    currentOutputDir = os.path.join(outputDir, application_data + '_' + model)
-    Path(currentOutputDir).mkdir(parents=True, exist_ok=True)
-    TrainingManager(dataframe=training_data, headers = headers, outputDir=currentOutputDir, parameters=parameters, device='cpu', reset_prev=True)
+    shutil.rmtree(outputDir) # overwrite previous results
+    Path(outputDir).mkdir(parents=True, exist_ok=True)
+    TrainingManager(dataframe=training_data, headers = headers, outputDir=outputDir, parameters=parameters, device='cpu', reset_prev=True)
 
   print('passed')
 
@@ -111,9 +111,9 @@ def test_train_segmentation_rad_3d():
   training_data, headers = parseTrainingCSV(inputDir + '/train_' + application_data + '.csv')
   for model in all_models_segmentation:
     parameters['model']['architecture'] = model 
-    currentOutputDir = os.path.join(outputDir, application_data + '_' + model)
-    Path(currentOutputDir).mkdir(parents=True, exist_ok=True)
-    TrainingManager(dataframe=training_data, headers = headers, outputDir=currentOutputDir, parameters=parameters, device='cpu', reset_prev=True)
+    shutil.rmtree(outputDir) # overwrite previous results
+    Path(outputDir).mkdir(parents=True, exist_ok=True)
+    TrainingManager(dataframe=training_data, headers = headers, outputDir=outputDir, parameters=parameters, device='cpu', reset_prev=True)
 
   print('passed')
 
@@ -123,9 +123,9 @@ def test_regression_rad_2d():
   training_data, headers = parseTrainingCSV(inputDir + '/train_2d_rad_regression.csv')
   for model in all_models_regression:
     parameters['model']['architecture'] = model 
-    currentOutputDir = os.path.join(outputDir, application_data + '_' + model + '_regression')
-    Path(currentOutputDir).mkdir(parents=True, exist_ok=True)
-    TrainingManager(dataframe=training_data, headers = headers, outputDir=currentOutputDir, parameters=parameters, device='cpu', reset_prev=True)
+    shutil.rmtree(outputDir) # overwrite previous results
+    Path(outputDir).mkdir(parents=True, exist_ok=True)
+    TrainingManager(dataframe=training_data, headers = headers, outputDir=outputDir, parameters=parameters, device='cpu', reset_prev=True)
 
   print('passed')
 
@@ -135,9 +135,9 @@ def test_regression_rad_3d():
   training_data, headers = parseTrainingCSV(inputDir + '/train_3d_rad_regression.csv')
   for model in all_models_regression:
     parameters['model']['architecture'] = model 
-    currentOutputDir = os.path.join(outputDir, application_data + '_' + model + '_regression')
-    Path(currentOutputDir).mkdir(parents=True, exist_ok=True)
-    TrainingManager(dataframe=training_data, headers = headers, outputDir=currentOutputDir, parameters=parameters, device='cpu', reset_prev=True)
+    shutil.rmtree(outputDir) # overwrite previous results
+    Path(outputDir).mkdir(parents=True, exist_ok=True)
+    TrainingManager(dataframe=training_data, headers = headers, outputDir=outputDir, parameters=parameters, device='cpu', reset_prev=True)
 
   print('passed')
 
@@ -145,11 +145,13 @@ def test_classification_rad_2d():
   application_data = '2d_rad_segmentation'
   parameters = parseConfig(inputDir + '/' + application_data + '/sample_training_classification.yaml')
   training_data, headers = parseTrainingCSV(inputDir + '/train_2d_rad_classification.csv')
+  shutil.rmtree(outputDir) # overwrite previous results
+  Path(outputDir).mkdir(parents=True, exist_ok=True)
   for model in all_models_regression:
     parameters['model']['architecture'] = model 
-    currentOutputDir = os.path.join(outputDir, application_data + '_' + model + '_classification')
-    Path(currentOutputDir).mkdir(parents=True, exist_ok=True)
-    TrainingManager(dataframe=training_data, headers = headers, outputDir=currentOutputDir, parameters=parameters, device='cpu', reset_prev=True)
+    shutil.rmtree(outputDir) # overwrite previous results
+    Path(outputDir).mkdir(parents=True, exist_ok=True)
+    TrainingManager(dataframe=training_data, headers = headers, outputDir=outputDir, parameters=parameters, device='cpu', reset_prev=True)
 
   print('passed')
 
@@ -159,8 +161,8 @@ def test_classification_rad_3d():
   training_data, headers = parseTrainingCSV(inputDir + '/train_3d_rad_classification.csv')
   for model in all_models_regression:
     parameters['model']['architecture'] = model 
-    currentOutputDir = os.path.join(outputDir, application_data + '_' + model + '_classification')
-    Path(currentOutputDir).mkdir(parents=True, exist_ok=True)
-    TrainingManager(dataframe=training_data, headers = headers, outputDir=currentOutputDir, parameters=parameters, device='cpu', reset_prev=True)
+    shutil.rmtree(outputDir) # overwrite previous results
+    Path(outputDir).mkdir(parents=True, exist_ok=True)
+    TrainingManager(dataframe=training_data, headers = headers, outputDir=outputDir, parameters=parameters, device='cpu', reset_prev=True)
 
   print('passed')


### PR DESCRIPTION
Fixes issue #12 

## Proposed Changes
<!-- Bullet pointed list of changes, please try to keep code changes as small as possible-->
- added option for user to pre-split the training and validation CSVs
- version bump to 0.0.8-dev
  - removed version check for unit tests (they should work regardless of any version changes)

## Checklist

<!-- You do not need to complete all the items by the time you submit the pull request, 
but PRs are more likely to be merged quickly if all the tasks are done. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/CBICA/GaNDLF/blob/master/CONTRIBUTING.md) guide
- [x] My PR is based from the [current GANDLF master ](https://garygregory.wordpress.com/2016/11/10/how-to-catch-up-my-git-fork-to-master/)
- [x] Non-breaking change (would not break existing functionality): if changes breaks current code, please provide as many details as possible
- [x] Function/class source code documentation added/updated
- [x] [Usage documentation](https://github.com/CBICA/GaNDLF/blob/master/docs) has been updated, if appropriate
- [x] [History](https://github.com/CBICA/GaNDLF/blob/master/HISTORY.md) has been updated, if appropriate
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
