### PR TITLE
OpenSlide import is disabled if not using histology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__
 *.py.*
 *.pkl
 *.swp
+dist/*
 
 *DS_Store
 *output*

--- a/GANDLF/inference_loop.py
+++ b/GANDLF/inference_loop.py
@@ -28,12 +28,6 @@ import datetime
 import SimpleITK as sitk
 from torch.cuda.amp import autocast
 from GANDLF.data.ImagesFromDataFrame import ImagesFromDataFrame
-if os.name != 'nt':
-    '''
-    path inference is Linux-only because openslide for Windows works only for Python-3.8  whereas pickle5 works only for 3.6 and 3.7
-    '''
-    from GANDLF.inference_dataloader_histopath import InferTumorSegDataset
-    from openslide import OpenSlide
 from GANDLF.schd import *
 from GANDLF.losses import *
 from GANDLF.utils import *
@@ -130,6 +124,11 @@ if os.name != 'nt':
     path inference is Linux-only because openslide for Windows works only for Python-3.8  whereas pickle5 works only for 3.6 and 3.7
     ''' 
     def inferenceLoopPath(inferenceDataFromPickle, headers, device, parameters, outputDir):
+        '''
+        path inference is Linux-only because openslide for Windows works only for Python-3.8  whereas pickle5 works only for 3.6 and 3.7
+        '''
+        from GANDLF.inference_dataloader_histopath import InferTumorSegDataset
+        from openslide import OpenSlide
         '''
         This is the main inference loop for histopathology
         '''

--- a/GANDLF/inference_loop.py
+++ b/GANDLF/inference_loop.py
@@ -124,9 +124,6 @@ if os.name != 'nt':
     path inference is Linux-only because openslide for Windows works only for Python-3.8  whereas pickle5 works only for 3.6 and 3.7
     ''' 
     def inferenceLoopPath(inferenceDataFromPickle, headers, device, parameters, outputDir):
-        '''
-        path inference is Linux-only because openslide for Windows works only for Python-3.8  whereas pickle5 works only for 3.6 and 3.7
-        '''
         from GANDLF.inference_dataloader_histopath import InferTumorSegDataset
         from openslide import OpenSlide
         '''

--- a/GANDLF/utils.py
+++ b/GANDLF/utils.py
@@ -262,6 +262,8 @@ def get_metrics_save_mask(model, device, loader, psize, channel_keys, value_keys
                     path_to_metadata = subject['path_to_metadata'][0]
                     inputImage = sitk.ReadImage(path_to_metadata)
                     _, ext = os.path.splitext(path_to_metadata)
+                    if ext == '.gz':
+                        ext = '.nii.gz'
                     pred_mask = pred_mask.numpy()
                     pred_mask = reverse_one_hot(pred_mask[0],class_list)
                     if not(model_2d):

--- a/GANDLF/utils.py
+++ b/GANDLF/utils.py
@@ -168,6 +168,7 @@ def resize_image(input_image, output_size, interpolator = sitk.sitkLinear):
         outputSpacing[i] = inputSpacing[i] * (inputSize[i] / output_size[i])
     resampler = sitk.ResampleImageFilter()
     resampler.SetSize(output_size)
+    resampler.SetInterpolator(interpolator)
     resampler.SetOutputSpacing(outputSpacing)
     resampler.SetOutputOrigin(input_image.GetOrigin())
     resampler.SetOutputDirection(input_image.GetDirection())
@@ -272,8 +273,7 @@ def get_metrics_save_mask(model, device, loader, psize, channel_keys, value_keys
                         result_image = pred_mask
                     result_image.CopyInformation(inputImage)
                     # if parameters['resize'] is not None:
-                    #     originalSize = inputImage.GetSize()
-                    #     result_image = resize_image(resize_image, originalSize, sitk.sitkNearestNeighbor) # change this for resample
+                    #     result_image = resize_image(result_image, inputImage.GetSize(), sitk.sitkNearestNeighbor) # change this for resample
                     sitk.WriteImage(result_image, os.path.join(outputDir, patient_name + '_seg' + ext))
                 elif len(value_keys) > 0:
                     outputToWrite += patient_name + ',' + str(pred_output / scaling_factor) + '\n'


### PR DESCRIPTION
<!-- Replace (issue_number) with the issue that will be auto-linked to close after merging this PR -->
Fixes #N.A.

## Proposed Changes
<!-- Bullet pointed list of changes, please try to keep code changes as small as possible-->
- openslide is imported only when performing histology inference
- makes life **much** simpler for people only interested in radiology

## Checklist

<!-- You do not need to complete all the items by the time you submit the pull request, 
but PRs are more likely to be merged quickly if all the tasks are done. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/CBICA/GaNDLF/blob/master/CONTRIBUTING.md) guide
- [x] My PR is based from the [current GANDLF master ](https://garygregory.wordpress.com/2016/11/10/how-to-catch-up-my-git-fork-to-master/)
- [x] Non-breaking change (would not break existing functionality): if changes breaks current code, please provide as many details as possible
- [x] Function/class source code documentation added/updated
- [x] [Usage documentation](https://github.com/CBICA/GaNDLF/blob/master/docs) has been updated, if appropriate
- [x] [History](https://github.com/CBICA/GaNDLF/blob/master/HISTORY.md) has been updated, if appropriate
- [x] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
