### PR TITLE
Add functionality to save training patches

### DIFF
--- a/GANDLF/compute/training_loop.py
+++ b/GANDLF/compute/training_loop.py
@@ -116,7 +116,7 @@ def train_network(model, train_dataloader, optimizer, params):
                         training_output_dir_current_subject, "modality_" + key + ext
                     ),
                 )
-    
+
             for key in params["label_keys"]:
                 img_to_write = subject[key].as_sitk()
                 ext = get_filename_extension_sanitized(subject["path_to_metadata"][0])

--- a/GANDLF/compute/training_loop.py
+++ b/GANDLF/compute/training_loop.py
@@ -1,9 +1,7 @@
 import os, time, psutil
-from pathlib import Path
 import torch
 from torch.utils.data import DataLoader
 from tqdm import tqdm
-import SimpleITK as sitk
 import torchio
 from medcam import medcam
 

--- a/GANDLF/compute/training_loop.py
+++ b/GANDLF/compute/training_loop.py
@@ -21,7 +21,7 @@ from GANDLF.utils import (
     save_model,
     load_model,
     version_check,
-    get_filename_extension_sanitized,
+    write_training_patches,
 )
 from GANDLF.logger import Logger
 from .step import step
@@ -99,7 +99,7 @@ def train_network(model, train_dataloader, optimizer, params):
             training_output_dir = os.path.join(params["output_dir"], "training_patches")
             Path(training_output_dir).mkdir(parents=True, exist_ok=True)
             training_output_dir_epoch = os.path.join(
-                params["output_dir"], "training_patches", params["current_epoch"]
+                training_output_dir, str(params["current_epoch"])
             )
             Path(training_output_dir_epoch).mkdir(parents=True, exist_ok=True)
             training_output_dir_current_subject = os.path.join(
@@ -107,25 +107,7 @@ def train_network(model, train_dataloader, optimizer, params):
             )
             Path(training_output_dir_current_subject).mkdir(parents=True, exist_ok=True)
 
-            for key in params["channel_keys"]:
-                img_to_write = subject[key].as_sitk()
-                ext = get_filename_extension_sanitized(subject["path_to_metadata"][0])
-                sitk.Write(
-                    img_to_write,
-                    os.path.join(
-                        training_output_dir_current_subject, "modality_" + key + ext
-                    ),
-                )
-
-            for key in params["label_keys"]:
-                img_to_write = subject[key].as_sitk()
-                ext = get_filename_extension_sanitized(subject["path_to_metadata"][0])
-                sitk.Write(
-                    img_to_write,
-                    os.path.join(
-                        training_output_dir_current_subject, "label_" + key + ext
-                    ),
-                )
+            write_training_patches(subject, params, training_output_dir_current_subject)
 
         # ensure spacing is always present in params and is always subject-specific
         if "spacing" in subject:

--- a/GANDLF/compute/training_loop.py
+++ b/GANDLF/compute/training_loop.py
@@ -95,7 +95,10 @@ def train_network(model, train_dataloader, optimizer, params):
         label = label.to(params["device"])
 
         if params["save_training"]:
-            write_training_patches(subject, params, )
+            write_training_patches(
+                subject,
+                params,
+            )
 
         # ensure spacing is always present in params and is always subject-specific
         if "spacing" in subject:

--- a/GANDLF/compute/training_loop.py
+++ b/GANDLF/compute/training_loop.py
@@ -116,7 +116,7 @@ def train_network(model, train_dataloader, optimizer, params):
                         training_output_dir_current_subject, "modality_" + key + ext
                     ),
                 )
-
+    
             for key in params["label_keys"]:
                 img_to_write = subject[key].as_sitk()
                 ext = get_filename_extension_sanitized(subject["path_to_metadata"][0])

--- a/GANDLF/compute/training_loop.py
+++ b/GANDLF/compute/training_loop.py
@@ -95,19 +95,7 @@ def train_network(model, train_dataloader, optimizer, params):
         label = label.to(params["device"])
 
         if params["save_training"]:
-            # create folder tree for saving the patches
-            training_output_dir = os.path.join(params["output_dir"], "training_patches")
-            Path(training_output_dir).mkdir(parents=True, exist_ok=True)
-            training_output_dir_epoch = os.path.join(
-                training_output_dir, str(params["current_epoch"])
-            )
-            Path(training_output_dir_epoch).mkdir(parents=True, exist_ok=True)
-            training_output_dir_current_subject = os.path.join(
-                training_output_dir_epoch, subject["subject_id"][0]
-            )
-            Path(training_output_dir_current_subject).mkdir(parents=True, exist_ok=True)
-
-            write_training_patches(subject, params, training_output_dir_current_subject)
+            write_training_patches(subject, params, )
 
         # ensure spacing is always present in params and is always subject-specific
         if "spacing" in subject:

--- a/GANDLF/parseConfig.py
+++ b/GANDLF/parseConfig.py
@@ -9,6 +9,7 @@ parameter_defaults = {
     "verbose": False,  # general application verbosity
     "q_verbose": False,  # queue construction verbosity
     "medcam_enabled": False,  # interpretability via medcam
+    "save_training": False,  # save outputs during training
     "save_output": False,  # save outputs during validation/testing
     "in_memory": False,  # pin data to cpu memory
     "pin_memory_dataloader": False,  # pin data to gpu memory

--- a/GANDLF/utils/__init__.py
+++ b/GANDLF/utils/__init__.py
@@ -7,6 +7,7 @@ from .imaging import (
     resample_image,
     resize_image,
     perform_sanity_check_on_subject,
+    write_training_patches,
 )
 
 from .tensor import (

--- a/GANDLF/utils/imaging.py
+++ b/GANDLF/utils/imaging.py
@@ -196,7 +196,6 @@ def write_training_patches(subject, params):
     )
     pathlib.Path(training_output_dir_current_subject).mkdir(parents=True, exist_ok=True)
 
-    write_training_patches(subject, params, training_output_dir_current_subject)
     # write the training patches to disk
     ext = get_filename_extension_sanitized(subject["path_to_metadata"][0])
     for key in params["channel_keys"]:

--- a/GANDLF/utils/imaging.py
+++ b/GANDLF/utils/imaging.py
@@ -188,19 +188,20 @@ def write_training_patches(subject, params, output_dir):
     # write the training patches to disk
     ext = get_filename_extension_sanitized(subject["path_to_metadata"][0])
     for key in params["channel_keys"]:
-        img_to_write = torchio.ScalarImage(tensor=subject[key][torchio.DATA][0], affine=subject[key]["affine"][0]).as_sitk()
+        img_to_write = torchio.ScalarImage(
+            tensor=subject[key][torchio.DATA][0], affine=subject[key]["affine"][0]
+        ).as_sitk()
         sitk.WriteImage(
             img_to_write,
-            os.path.join(
-                output_dir, "modality_" + key + ext
-            ),
+            os.path.join(output_dir, "modality_" + key + ext),
         )
 
     if params["label_keys"] is not None:
-        img_to_write = torchio.ScalarImage(tensor=subject[params["label_keys"][0]][torchio.DATA][0], affine=subject[key]["affine"][0]).as_sitk()
+        img_to_write = torchio.ScalarImage(
+            tensor=subject[params["label_keys"][0]][torchio.DATA][0],
+            affine=subject[key]["affine"][0],
+        ).as_sitk()
         sitk.WriteImage(
             img_to_write,
-            os.path.join(
-                output_dir, "label_" + key + ext
-            ),
+            os.path.join(output_dir, "label_" + key + ext),
         )

--- a/GANDLF/utils/imaging.py
+++ b/GANDLF/utils/imaging.py
@@ -182,9 +182,7 @@ def write_training_patches(subject, params):
 
     Args:
         subject (torchio.Subject): The input subject.
-        params (dict): The parameters passed by the user yaml.
-        output_dir (str): The output directory to write the patches to.
-        current_epoch (str): The current epoch.
+        params (dict): The parameters passed by the user yaml; needs the "output_dir" and "current_epoch" keys to be present.
     """
     # create folder tree for saving the patches
     training_output_dir = os.path.join(params["output_dir"], "training_patches")

--- a/GANDLF/utils/parameter_processing.py
+++ b/GANDLF/utils/parameter_processing.py
@@ -83,14 +83,19 @@ def populate_channel_keys_in_params(data_loader, parameters):
     all_keys = list(batch.keys())
     channel_keys = []
     value_keys = []
+    label_keys = []
     print("All Keys : ", all_keys)
     for item in all_keys:
         if item.isnumeric():
             channel_keys.append(item)
         elif "value" in item:
             value_keys.append(item)
+        elif "label" in item:
+            label_keys.append(item)
     parameters["channel_keys"] = channel_keys
     if value_keys:
         parameters["value_keys"] = value_keys
+    if label_keys:
+        parameters["label_keys"] = label_keys
 
     return parameters

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 ## 0.0.14
 
-- 
+- Add an option (`"save_training"`) to save training patches
 
 ## 0.0.13
 

--- a/gandlf_collectStats
+++ b/gandlf_collectStats
@@ -25,7 +25,7 @@ def main():
     )
 
     parser = argparse.ArgumentParser(
-        prog="GANDLF_CollectCSV",
+        prog="GANDLF_CollectStats",
         formatter_class=argparse.RawTextHelpFormatter,
         description="Collect statistics from different testing/validation combinations from output directory.\n\n"
         + copyrightMessage,

--- a/gandlf_patchMiner
+++ b/gandlf_patchMiner
@@ -12,7 +12,6 @@ import argparse
 import pandas as pd
 import openslide
 import numpy as np
-import yaml
 
 from PIL import Image
 from GANDLF.OPM.opm.patch_manager import PatchManager
@@ -85,13 +84,18 @@ if __name__ == "__main__":
         "--config",
         type=str,
         dest="config",
-        help="config.yml for running OPM. ",
-        required=True,
+        help="config (in YAML) for running OPM. Needs 'scale' and 'patch_size' to be defined, otherwise defaults to 16 and (256, 256), respectively.",
+        required=False,
     )
 
     args = parser.parse_args()
 
-    cfg = parse_config(args.config)
+    if args.config is not None:
+        cfg = parse_config(args.config)
+    else:
+        cfg = {}
+        cfg["scale"] = 16
+        cfg["patch_size"] = (256, 256)
 
     if not os.path.exists(args.output_path):
         Path(args.output_path).mkdir(parents=True, exist_ok=True)

--- a/gandlf_patchMiner
+++ b/gandlf_patchMiner
@@ -16,7 +16,12 @@ import yaml
 
 from PIL import Image
 from GANDLF.OPM.opm.patch_manager import PatchManager
-from GANDLF.OPM.opm.utils import tissue_mask, alpha_channel_check, patch_size_check, parse_config
+from GANDLF.OPM.opm.utils import (
+    tissue_mask,
+    alpha_channel_check,
+    patch_size_check,
+    parse_config,
+)
 from functools import partial
 from pathlib import Path
 
@@ -35,7 +40,7 @@ def generate_initial_mask(slide_path, scale):
     slide = openslide.open_slide(slide_path)
     slide_dims = slide.dimensions
 
-    # Call thumbnail for effiency, calculate scale relative to whole slide
+    # Call thumbnail for efficiency, calculate scale relative to whole slide
     slide_thumbnail = np.asarray(
         slide.get_thumbnail((slide_dims[0] // scale, slide_dims[1] // scale))
     )
@@ -102,6 +107,8 @@ if __name__ == "__main__":
         manager = PatchManager(slide, args.output_path)
         manager.set_label_map(label)
         manager.set_subjectID(sid)
+        manager.set_image_header("Channel_0")
+        manager.set_mask_header("Label")
 
         # Generate an initial validity mask
         mask, scale = generate_initial_mask(slide, cfg["scale"])
@@ -119,3 +126,5 @@ if __name__ == "__main__":
         # Save patches releases saves all patches stored in manager, dumps to specified output file
         manager.mine_patches(output_csv=out_csv_path, config=cfg)
         print("Total time: {}".format(time.time() - start))
+
+    print("Finished.")

--- a/gandlf_patchMiner
+++ b/gandlf_patchMiner
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+from datetime import date
 from GANDLF.utils import *
 
 fix_paths(os.getcwd())  # add relevant vips path
@@ -10,8 +11,6 @@ import time
 import warnings
 import argparse
 import pandas as pd
-import openslide
-import numpy as np
 
 from PIL import Image
 from GANDLF.OPM.opm.patch_manager import PatchManager
@@ -40,7 +39,19 @@ def parse_gandlf_csv(fpath):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    copyrightMessage = (
+        "Contact: software@cbica.upenn.edu\n\n"
+        + "This program is NOT FDA/CE approved and NOT intended for clinical use.\nCopyright (c) "
+        + str(date.today().year)
+        + " University of Pennsylvania. All rights reserved."
+    )
+
+    parser = argparse.ArgumentParser(
+        prog="GANDLF_PatchMiner",
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="Construct patches from whole slide image(s).\n\n"
+        + copyrightMessage,
+    )
 
     parser.add_argument(
         "-i",

--- a/samples/config_all_options.yaml
+++ b/samples/config_all_options.yaml
@@ -37,6 +37,8 @@ metrics:
 in_memory: False
 # this will save the generated masks for validation and testing data for qualitative analysis
 save_output: False
+# this will save the patches used during training for qualitative analysis
+save_training: False
 # If enabled, this parameter pads images and labels when label sampler is used
 enable_padding: False
 # Set the Modality : rad for radiology, path for histopathology

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ requirements = [
     "psutil",
     "medcam",
     "torchmetrics",
+    "zarr",
 ]
 
 setup(

--- a/testing/test_full.py
+++ b/testing/test_full.py
@@ -871,6 +871,7 @@ def test_dataloader_construction_train_segmentation_3d(device):
     )
     parameters = populate_header_in_parameters(parameters, parameters["headers"])
     parameters["patch_size"] = patch_size["3D"]
+    parameters["save_training"] = True
     parameters["model"]["dimension"] = 3
     parameters["model"]["class_list"] = [0, 1]
     parameters["model"]["amp"] = True


### PR DESCRIPTION
<!-- Replace ISSUE_NUMBER with the issue that will be auto-linked to close after merging this PR -->
Fixes #262

## Proposed Changes
<!-- Bullet pointed list of changes, please try to keep code changes as small as possible-->
- training patches can now be saved by added `save_training: True` in config
- includes #261

## Checklist

<!-- You do not need to complete all the items by the time you submit the pull request, 
but PRs are more likely to be merged quickly if all the tasks are done. -->

<!-- Replace `[ ]` with `[x]` in all the boxes that apply.
Note that if a box is left unchecked, PR merges will take longer than usual.
-->
- [x] I have read the [`CONTRIBUTING`](https://github.com/CBICA/GaNDLF/blob/master/CONTRIBUTING.md) guide
- [x] My PR is based from the [current GaNDLF master ](https://garygregory.wordpress.com/2016/11/10/how-to-catch-up-my-git-fork-to-master/)
- [x] Non-breaking change (would not break existing functionality): please provide as many details as possible for any breaking change 
- [x] Function/class source code documentation added/updated
- [x] Code has been [blacked](https://github.com/psf/black#usage) for style consistency
- [x] If applicable, version information [has been updated in GANDLF/version.py](https://github.com/CBICA/GaNDLF/blob/master/GANDLF/version.py)
- [x] If adding a submodule, add to list of exceptions for black styling in [pyproject.toml](https://github.com/CBICA/GaNDLF/blob/master/pyproject.toml) file 
- [x] [Usage documentation](https://github.com/CBICA/GaNDLF/blob/master/docs) has been updated, if appropriate
- [x] [History](https://github.com/CBICA/GaNDLF/blob/master/HISTORY.md) has been updated, if appropriate
- [x] Tests added or modified to [cover the changes](https://app.codecov.io/gh/CBICA/GaNDLF); if coverage is reduced, please give explanation
