### PR TITLE
Fixing pytorch version dependency for macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ requirements = [
     "numpy==1.21.0",
     "scipy",
     "SimpleITK!=2.0.*",
-    "torch==1.8.2",
     "torchvision",
     "tqdm",
     "torchio==0.18.57",
@@ -81,6 +80,12 @@ requirements = [
     "pydicom",
     "onnx",
 ]
+
+# pytorch doesn't have LTS support on OSX - https://github.com/CBICA/GaNDLF/issues/389
+if sys.platform == "darwin":
+    requirements.append("torch==1.9.0")
+else:
+    requirements.append("torch==1.8.2")
 
 setup(
     name="GANDLF",


### PR DESCRIPTION
<!-- Replace ISSUE_NUMBER with the issue that will be auto-linked to close after merging this PR -->
Fixes #389

## Proposed Changes
<!-- Bullet pointed list of changes, please try to keep code changes as small as possible-->
- changes the required version of pytorch for macOS

## Checklist

<!-- You do not need to complete all the items by the time you submit the pull request, 
but PRs are more likely to be merged quickly if all the tasks are done. -->

<!-- Replace `[ ]` with `[x]` in all the boxes that apply.
Note that if a box is left unchecked, PR merges will take longer than usual.
-->
- [x] I have read the [`CONTRIBUTING`](https://github.com/CBICA/GaNDLF/blob/master/CONTRIBUTING.md) guide
- [x] My PR is based from the [current GaNDLF master ](https://garygregory.wordpress.com/2016/11/10/how-to-catch-up-my-git-fork-to-master/)
- [x] Non-breaking change (would not break existing functionality): please provide as many details as possible for any breaking change 
- [x] Function/class source code documentation added/updated
- [x] Code has been [blacked](https://github.com/psf/black#usage) for style consistency
- [x] If applicable, version information [has been updated in GANDLF/version.py](https://github.com/CBICA/GaNDLF/blob/master/GANDLF/version.py)
- [x] If adding a git submodule, add to list of exceptions for black styling in [pyproject.toml](https://github.com/CBICA/GaNDLF/blob/master/pyproject.toml) file 
- [x] [Usage documentation](https://github.com/CBICA/GaNDLF/blob/master/docs) has been updated, if appropriate
- [x] [History](https://github.com/CBICA/GaNDLF/blob/master/HISTORY.md) has been updated, if appropriate
- [x] Tests added or modified to [cover the changes](https://app.codecov.io/gh/CBICA/GaNDLF); if coverage is reduced, please give explanation
- [x] If customized dependency installation is required (i.e., a separate `pip install` step is needed for PR to be functional), please ensure it is reflected in all the files that control the CI, namely: [python-test.yml](https://github.com/CBICA/GaNDLF/blob/master/.github/workflows/python-test.yml), and all docker files [[1](https://github.com/CBICA/GaNDLF/blob/master/Dockerfile-CPU),[2](https://github.com/CBICA/GaNDLF/blob/master/Dockerfile-CUDA10.2),[3](https://github.com/CBICA/GaNDLF/blob/master/Dockerfile-CUDA11.3),[4](https://github.com/CBICA/GaNDLF/blob/master/Dockerfile-ROCm)] 
