### PR TITLE
Added a preprocessing dict for `resize_image`

### DIFF
--- a/GANDLF/data/ImagesFromDataFrame.py
+++ b/GANDLF/data/ImagesFromDataFrame.py
@@ -92,9 +92,10 @@ def ImagesFromDataFrame(
     if not (preprocessing is None):
         for key in preprocessing.keys():
             # check for different resizing keys
-            if key in ["resize_image", "resize_images"]:
+            if key in ["resize", "resize_image", "resize_images"]:
                 if not (preprocessing[key] is None):
                     resize_images_flag = True
+                    preprocessing["resize_image"] = preprocessing[key]
                     break
 
     # iterating through the dataframe

--- a/GANDLF/data/preprocessing/__init__.py
+++ b/GANDLF/data/preprocessing/__init__.py
@@ -127,13 +127,7 @@ def get_transforms_for_preprocessing(
         for preprocess in preprocessing_params_dict:
             preprocess_lower = preprocess.lower()
             # special check for resize and resample
-            if preprocess_lower == "resize":
-                resize_values = generic_3d_check(preprocessing_params_dict[preprocess])
-                current_transformations.append(Resize(resize_values))
-            elif preprocess_lower == "resize_image":
-                resize_values = generic_3d_check(preprocessing_params_dict[preprocess])
-                current_transformations.append(Resize(resize_values))
-            elif preprocess_lower == "resize_patch":
+            if preprocess_lower == "resize_patch":
                 resize_values = generic_3d_check(preprocessing_params_dict[preprocess])
                 current_transformations.append(Resize(resize_values))
             elif preprocess_lower == "resample":

--- a/GANDLF/data/preprocessing/__init__.py
+++ b/GANDLF/data/preprocessing/__init__.py
@@ -126,41 +126,42 @@ def get_transforms_for_preprocessing(
         # go through preprocessing in the order they are specified
         for preprocess in preprocessing_params_dict:
             preprocess_lower = preprocess.lower()
-            # special check for resample
+            # special check for resize and resample
             if preprocess_lower == "resize":
-                resize_values = generic_3d_check(preprocessing_params_dict["resize"])
+                resize_values = generic_3d_check(preprocessing_params_dict[preprocess])
+                current_transformations.append(Resize(resize_values))
+            elif preprocess_lower == "resize_image":
+                resize_values = generic_3d_check(preprocessing_params_dict[preprocess])
                 current_transformations.append(Resize(resize_values))
             elif preprocess_lower == "resize_patch":
-                resize_values = generic_3d_check(
-                    preprocessing_params_dict["resize_patch"]
-                )
+                resize_values = generic_3d_check(preprocessing_params_dict[preprocess])
                 current_transformations.append(Resize(resize_values))
             elif preprocess_lower == "resample":
-                if "resolution" in preprocessing_params_dict[preprocess_lower]:
+                if "resolution" in preprocessing_params_dict[preprocess]:
                     # Need to take a look here
                     resample_values = generic_3d_check(
-                        preprocessing_params_dict[preprocess_lower]["resolution"]
+                        preprocessing_params_dict[preprocess]["resolution"]
                     )
                     current_transformations.append(Resample(resample_values))
             elif preprocess_lower in ["resample_minimum", "resample_min"]:
-                if "resolution" in preprocessing_params_dict[preprocess_lower]:
+                if "resolution" in preprocessing_params_dict[preprocess]:
                     resample_values = generic_3d_check(
-                        preprocessing_params_dict[preprocess_lower]["resolution"]
+                        preprocessing_params_dict[preprocess]["resolution"]
                     )
                     current_transformations.append(Resample_Minimum(resample_values))
             # special check for histogram_matching
             elif preprocess_lower == "histogram_matching":
-                if preprocessing_params_dict[preprocess_lower] is not False:
+                if preprocessing_params_dict[preprocess] is not False:
                     current_transformations.append(
                         global_preprocessing_dict[preprocess_lower](
-                            preprocessing_params_dict[preprocess_lower]
+                            preprocessing_params_dict[preprocess]
                         )
                     )
             # special check for stain_normalizer
             elif preprocess_lower == "stain_normalizer":
                 if normalize_to_apply is None:
                     normalize_to_apply = global_preprocessing_dict[preprocess_lower](
-                        preprocessing_params_dict[preprocess_lower]
+                        preprocessing_params_dict[preprocess]
                     )
             # normalize should be applied at the end
             elif "normalize" in preprocess_lower:


### PR DESCRIPTION
<!-- Replace ISSUE_NUMBER with the issue that will be auto-linked to close after merging this PR -->
Fixes #N.A.

## Proposed Changes
<!-- Bullet pointed list of changes, please try to keep code changes as small as possible-->
- preprocessing dict extended to include `resize_image` which is same as `resize`

## Checklist

<!-- You do not need to complete all the items by the time you submit the pull request, 
but PRs are more likely to be merged quickly if all the tasks are done. -->

<!-- Replace `[ ]` with `[x]` in all the boxes that apply.
Note that if a box is left unchecked, PR merges will take longer than usual.
-->
- [x] I have read the [`CONTRIBUTING`](https://github.com/CBICA/GaNDLF/blob/master/CONTRIBUTING.md) guide
- [x] My PR is based from the [current GaNDLF master ](https://garygregory.wordpress.com/2016/11/10/how-to-catch-up-my-git-fork-to-master/)
- [x] Non-breaking change (would not break existing functionality): please provide as many details as possible for any breaking change 
- [x] Function/class source code documentation added/updated
- [x] Code has been [blacked](https://github.com/psf/black#usage) for style consistency
- [x] If applicable, version information [has been updated in GANDLF/version.py](https://github.com/CBICA/GaNDLF/blob/master/GANDLF/version.py)
- [x] If adding a git submodule, add to list of exceptions for black styling in [pyproject.toml](https://github.com/CBICA/GaNDLF/blob/master/pyproject.toml) file 
- [x] [Usage documentation](https://github.com/CBICA/GaNDLF/blob/master/docs) has been updated, if appropriate
- [x] [History](https://github.com/CBICA/GaNDLF/blob/master/HISTORY.md) has been updated, if appropriate
- [x] Tests added or modified to [cover the changes](https://app.codecov.io/gh/CBICA/GaNDLF); if coverage is reduced, please give explanation
- [x] If customized dependency installation is required (i.e., a separate `pip install` step is needed for PR to be functional), please ensure it is reflected in all the files that control the CI, namely: [python-test.yml](https://github.com/CBICA/GaNDLF/blob/master/.github/workflows/python-test.yml), and all docker files [[1](https://github.com/CBICA/GaNDLF/blob/master/Dockerfile-CPU),[2](https://github.com/CBICA/GaNDLF/blob/master/Dockerfile-CUDA10.2),[3](https://github.com/CBICA/GaNDLF/blob/master/Dockerfile-CUDA11.3),[4](https://github.com/CBICA/GaNDLF/blob/master/Dockerfile-ROCm)] 
