### PR TITLE
Supporting JPG for writing segmentation output

### DIFF
--- a/GANDLF/compute/forward_pass.py
+++ b/GANDLF/compute/forward_pass.py
@@ -340,9 +340,7 @@ def validate_network(
                     )
                     if ext in [".jpg", ".jpeg"]:
                         from tifffile import imwrite
-                        imwrite(
-                            path_to_write, sitk.GetArrayFromImage(result_image)
-                        )
+                        imwrite(path_to_write, sitk.GetArrayFromImage(result_image))
                     else:
                         sitk.WriteImage(
                             result_image,

--- a/GANDLF/compute/forward_pass.py
+++ b/GANDLF/compute/forward_pass.py
@@ -335,12 +335,19 @@ def validate_network(
                             img_for_metadata.GetSpacing(),
                             interpolator=sitk.sitkNearestNeighbor,
                         )
-                    sitk.WriteImage(
-                        result_image,
-                        os.path.join(
-                            current_output_dir, subject["subject_id"][0] + "_seg" + ext
-                        ),
+                    path_to_write = os.path.join(
+                        current_output_dir, subject["subject_id"][0] + "_seg" + ext
                     )
+                    if ext in [".jpg", ".jpeg"]:
+                        from tifffile import imwrite
+                        imwrite(
+                            path_to_write, sitk.GetArrayFromImage(result_image)
+                        )
+                    else:
+                        sitk.WriteImage(
+                            result_image,
+                            path_to_write,
+                        )
             else:
                 # final regression output
                 output_prediction = output_prediction / len(patch_loader)

--- a/GANDLF/compute/forward_pass.py
+++ b/GANDLF/compute/forward_pass.py
@@ -340,12 +340,11 @@ def validate_network(
                             img_for_metadata.GetSpacing(),
                             interpolator=sitk.sitkNearestNeighbor,
                         )
-                    path_to_write = os.path.join(
-                        current_output_dir, subject["subject_id"][0] + "_seg" + ext
-                    )
                     sitk.WriteImage(
                         result_image,
-                        path_to_write,
+                        os.path.join(
+                            current_output_dir, subject["subject_id"][0] + "_seg" + ext
+                        ),
                     )
             else:
                 # final regression output

--- a/GANDLF/compute/forward_pass.py
+++ b/GANDLF/compute/forward_pass.py
@@ -340,6 +340,7 @@ def validate_network(
                     )
                     if ext in [".jpg", ".jpeg"]:
                         from tifffile import imwrite
+
                         imwrite(path_to_write, sitk.GetArrayFromImage(result_image))
                     else:
                         sitk.WriteImage(

--- a/GANDLF/compute/forward_pass.py
+++ b/GANDLF/compute/forward_pass.py
@@ -324,7 +324,7 @@ def validate_network(
                     if jpg_detected:
                         pred_mask = pred_mask.astype(np.uint8)
                     else:
-                        pred_mask = pred_mask.astype(np.int16)
+                        pred_mask = pred_mask.astype(np.uint16)
 
                     ## special case for 2D
                     if image.shape[-1] > 1:

--- a/GANDLF/compute/forward_pass.py
+++ b/GANDLF/compute/forward_pass.py
@@ -320,7 +320,7 @@ def validate_network(
                     for postprocessor in params["data_postprocessing"]:
                         pred_mask = global_postprocessing_dict[postprocessor](
                             pred_mask, params
-                        )
+                        ).numpy()
                     if jpg_detected:
                         pred_mask = pred_mask.astype(np.uint8)
                     else:

--- a/GANDLF/compute/inference_loop.py
+++ b/GANDLF/compute/inference_loop.py
@@ -296,7 +296,7 @@ def inference_loop(
                         out_probs_map[n, ...] * 255 / out_probs_map[n, ...].max(),
                         dtype=np.uint8,
                     )
-                    heatmap = cv2.applyColorMap(image, cv2.COLORMAP_HOT)
+                    heatmap = cv2.applyColorMap(image, cv2.COLORMAP_JET)
                     cv2.imwrite(file_to_write, heatmap)
 
 

--- a/GANDLF/data/post_process/tensor.py
+++ b/GANDLF/data/post_process/tensor.py
@@ -28,4 +28,4 @@ def get_mapped_label(input_tensor, params):
     for key, value in mapping.items():
         output[input_arr == key] = value
 
-    return output
+    return torch.from_numpy(output)

--- a/testing/test_full.py
+++ b/testing/test_full.py
@@ -1537,7 +1537,7 @@ def test_one_hot_logic():
     parameters = {"data_postprocessing": {"mapping": {0: 0, 1: 1, 2: 5}}}
     mapped_output = get_mapped_label(
         torch.from_numpy(img_tensor_oh_rev_array), parameters
-    )
+    ).numpy()
 
     for key, value in parameters["data_postprocessing"]["mapping"].items():
         comparison = (img_tensor_oh_rev_array == key) == (mapped_output == value)


### PR DESCRIPTION
<!-- Replace ISSUE_NUMBER with the issue that will be auto-linked to close after merging this PR -->
Fixes #431

## Proposed Changes
<!-- Bullet pointed list of changes, please try to keep code changes as small as possible-->
- if jpg is detected, cast to 8-bit
- ensure tensor output from post-processing module

## Checklist

<!-- You do not need to complete all the items by the time you submit the pull request, 
but PRs are more likely to be merged quickly if all the tasks are done. -->

<!-- Replace `[ ]` with `[x]` in all the boxes that apply.
Note that if a box is left unchecked, PR merges will take longer than usual.
-->
- [x] I have read the [`CONTRIBUTING`](https://github.com/CBICA/GaNDLF/blob/master/CONTRIBUTING.md) guide
- [x] My PR is based from the [current GaNDLF master ](https://garygregory.wordpress.com/2016/11/10/how-to-catch-up-my-git-fork-to-master/)
- [x] Non-breaking change (would not break existing functionality): please provide as many details as possible for any breaking change 
- [x] Function/class source code documentation added/updated
- [x] Code has been [blacked](https://github.com/psf/black#usage) for style consistency
- [x] If applicable, version information [has been updated in GANDLF/version.py](https://github.com/CBICA/GaNDLF/blob/master/GANDLF/version.py)
- [x] If adding a git submodule, add to list of exceptions for black styling in [pyproject.toml](https://github.com/CBICA/GaNDLF/blob/master/pyproject.toml) file 
- [x] [Usage documentation](https://github.com/CBICA/GaNDLF/blob/master/docs) has been updated, if appropriate
- [x] [History](https://github.com/CBICA/GaNDLF/blob/master/HISTORY.md) has been updated, if appropriate
- [x] Tests added or modified to [cover the changes](https://app.codecov.io/gh/CBICA/GaNDLF); if coverage is reduced, please give explanation
- [x] If customized dependency installation is required (i.e., a separate `pip install` step is needed for PR to be functional), please ensure it is reflected in all the files that control the CI, namely: [python-test.yml](https://github.com/CBICA/GaNDLF/blob/master/.github/workflows/python-test.yml), and all docker files [[1](https://github.com/CBICA/GaNDLF/blob/master/Dockerfile-CPU),[2](https://github.com/CBICA/GaNDLF/blob/master/Dockerfile-CUDA10.2),[3](https://github.com/CBICA/GaNDLF/blob/master/Dockerfile-CUDA11.3),[4](https://github.com/CBICA/GaNDLF/blob/master/Dockerfile-ROCm)] 
