### PR TITLE
Add collectStats functionality for classification tasks

### DIFF
--- a/gandlf_collectStats
+++ b/gandlf_collectStats
@@ -6,6 +6,7 @@ import sys
 import argparse
 import subprocess
 import pathlib
+import ast
 from pathlib import Path
 from datetime import date
 import numpy as np
@@ -44,6 +45,14 @@ def main():
         type=str,
         help="Output directory to save stats and plot",
     )
+    parser.add_argument(
+        "-c",
+        "--combinedplots",
+        metavar="",
+        default=False,
+        type=ast.literal_eval,
+        help="Overlays training and validation plots for both accuracy and loss (classification only).",
+    )
 
     args = parser.parse_args()
 
@@ -53,77 +62,214 @@ def main():
     outputFile = os.path.join(outputDir, "data.csv")  # data file name
     outputPlot = os.path.join(outputDir, "plot.png")  # plot file
 
-    final_stats = "Epoch,Train_Loss,Train_Dice,Val_Loss,Val_Dice,Testing_Loss,Testing_Dice\n"  # the columns that need to be present in final output; epoch is always removed
+    combinedPlots = args.combinedplots
 
-    # loop through output directory
-    for dirs in os.listdir(inputDir):
+    trainingLogs = os.path.join(inputDir, "logs_training.csv")
+    validationLogs = os.path.join(inputDir, "logs_validation.csv")
+    testingLogs = os.path.join(inputDir, "logs_testing.csv")
 
-        currentTestingDir = os.path.join(inputDir, dirs)
-        if os.path.isdir(currentTestingDir):  # go in only if it is a directory
-            if "testing_" in dirs:  # ensure it is part of the testing structure
+    if os.path.exists(testingLogs):
 
-                for val in os.listdir(
-                    currentTestingDir
-                ):  # loop through all validation directories
+        testingLogsCSV = pd.read_csv(testingLogs)
 
-                    currentValidationDir = os.path.join(currentTestingDir, val)
-                    if os.path.isdir(currentValidationDir):
+        if len(testingLogsCSV) == 0:  # check for classification task
 
-                        filesInDir = os.listdir(
-                            currentValidationDir
-                        )  # get all files in each directory
+            print("Classification task detected, generating accuracy and loss plots.")
 
-                        for i, n in enumerate(filesInDir):
-                            # when the log has been found, collect the final numbers
-                            if "trainingScores_log" in n:
+            if (
+                combinedPlots
+            ):  # check whether user wants training + validation overlayed plots
 
-                                log_file = os.path.join(currentValidationDir, n)
-                                with open(log_file) as f:
-                                    for line in f:
-                                        pass
-                                    final_stats = final_stats + line
+                df_training = pd.read_csv(trainingLogs)
+                df_validation = pd.read_csv(validationLogs)
 
-    data_string = StringIO(final_stats)
-    data_full = pd.read_csv(data_string, sep=",")
-    del data_full["Epoch"]  # no need for epoch
-    data_full.to_csv(outputFile, index=False)  # save updated data
+                epochs = len(df_training)
 
-    # perform deep copy
-    data_loss = data_full.copy()
-    data_dice = data_full.copy()
+                fig, axes = plt.subplots(nrows=1, ncols=2)  # set plot properties
 
-    cols = ["Train", "Val", "Testing"]  # set the datasets that need to be plotted
-    for i in cols:
+                plt.subplots_adjust(
+                    wspace=0.5, hspace=0.5
+                )  # ensure spacing between plots
 
-        del data_dice[i + "_Loss"]  # keep only dice
-        del data_loss[i + "_Dice"]  # keep only loss
+                splot = sns.lineplot(
+                    data=df_training,
+                    x="epoch_no",
+                    y="train_balanced_accuracy",
+                    ax=axes[0],
+                )  # plot training accuracy data
+                splot = sns.lineplot(
+                    data=df_validation,
+                    x="epoch_no",
+                    y="valid_balanced_accuracy",
+                    ax=axes[0],
+                )  # plot validation accuracy data
+                splot.set(
+                    xlim=(0, epochs - 1)
+                )  # set limits for x-axis for proper visualization
+                splot.set(ylim=(0, 1))  # set limits for y-axis for proper visualization
+                splot.set(
+                    xlabel="Epoch", ylabel="Accuracy", title="Accuracy Plot"
+                )  # add labels and title to plot
+                axes[0].legend(labels=["Training", "Validation"])  # add legend to plot
 
-        data_loss.rename(columns={i + "_Loss": i}, inplace=True)  # rename the columns
-        data_dice.rename(columns={i + "_Dice": i}, inplace=True)  # rename the columns
+                splot = sns.lineplot(
+                    data=df_training, x="epoch_no", y="train_loss", ax=axes[1]
+                )  # plot training loss data
+                splot = sns.lineplot(
+                    data=df_validation, x="epoch_no", y="valid_loss", ax=axes[1]
+                )  # plot validation loss data
+                splot.set(
+                    xlim=(0, epochs - 1)
+                )  # set limits for x-axis for proper visualization
+                splot.set(
+                    xlabel="Epoch", ylabel="Loss", title="Loss Plot"
+                )  # add labels and title to plot
+                axes[1].legend(labels=["Training", "Validation"])  # add legend to plot
 
-    fig, axes = plt.subplots(
-        nrows=1, ncols=2, constrained_layout=True
-    )  # set plot properties
+                plt.savefig(outputPlot, dpi=600)  # save plot
 
-    bplot = sns.boxplot(
-        data=data_dice, width=0.5, palette="colorblind", ax=axes[0]
-    )  # plot the data
-    bplot.set(ylim=(0, 1))  # set limits for y-axis for proper visualization
-    bplot.set(xlabel="Dataset", ylabel="Dice", title="Dice plot")  # set labels
-    bplot.set_xticklabels(
-        bplot.get_xticklabels(), rotation=15, ha="right"
-    )  # rotate so that everything is visible
+                print("Plots saved successfully.")
 
-    bplot = sns.boxplot(
-        data=data_loss, width=0.5, palette="colorblind", ax=axes[1]
-    )  # plot the data
-    bplot.set(ylim=(0, 1))  # set limits for y-axis for proper visualization
-    bplot.set(xlabel="Dataset", ylabel="Loss", title="Loss plot")  # set labels
-    bplot.set_xticklabels(
-        bplot.get_xticklabels(), rotation=15, ha="right"
-    )  # rotate so that everything is visible
+            else:
 
-    plt.savefig(outputPlot, dpi=600)
+                df_training = pd.read_csv(trainingLogs)
+                df_validation = pd.read_csv(validationLogs)
+
+                epochs = len(df_training)
+
+                fig, axes = plt.subplots(nrows=2, ncols=2)  # set plot properties
+
+                plt.subplots_adjust(wspace=0.5, hspace=0.5)
+
+                splot = sns.lineplot(
+                    data=df_training,
+                    x="epoch_no",
+                    y="train_balanced_accuracy",
+                    ax=axes[0, 0],
+                )  # plot the data
+                splot.set(xlim=(0, epochs - 1))
+                splot.set(ylim=(0, 1))  # set limits for y-axis for proper visualization
+                splot.set(
+                    xlabel="Epoch", ylabel="Accuracy", title="Training Accuracy Plot"
+                )  # set labels
+
+                splot = sns.lineplot(
+                    data=df_validation,
+                    x="epoch_no",
+                    y="valid_balanced_accuracy",
+                    ax=axes[0, 1],
+                )  # plot the data
+                splot.set(xlim=(0, epochs - 1))
+                splot.set(ylim=(0, 1))  # set limits for y-axis for proper visualization
+                splot.set(
+                    xlabel="Epoch", ylabel="Accuracy", title="Validation Accuracy Plot"
+                )  # set labels
+
+                splot = sns.lineplot(
+                    data=df_training, x="epoch_no", y="train_loss", ax=axes[1, 0]
+                )  # plot the data
+                splot.set(xlim=(0, epochs - 1))
+                splot.set(
+                    xlabel="Epoch", ylabel="Loss", title="Training Loss Plot"
+                )  # set labels
+
+                splot = sns.lineplot(
+                    data=df_validation, x="epoch_no", y="valid_loss", ax=axes[1, 1]
+                )  # plot the data
+                splot.set(xlim=(0, epochs - 1))
+                splot.set(
+                    xlabel="Epoch", ylabel="Loss", title="Validation Loss Plot"
+                )  # set labels
+
+                plt.savefig(outputPlot, dpi=600)
+
+                print("Plots saved successfully.")
+
+        else:
+
+            print("Segmentation task detected, generating dice and loss plots.")
+
+            final_stats = "Epoch,Train_Loss,Train_Dice,Val_Loss,Val_Dice,Testing_Loss,Testing_Dice\n"  # the columns that need to be present in final output; epoch is always removed
+
+            # loop through output directory
+            for dirs in os.listdir(inputDir):
+
+                currentTestingDir = os.path.join(inputDir, dirs)
+                if os.path.isdir(currentTestingDir):  # go in only if it is a directory
+                    if "testing_" in dirs:  # ensure it is part of the testing structure
+
+                        for val in os.listdir(
+                            currentTestingDir
+                        ):  # loop through all validation directories
+
+                            currentValidationDir = os.path.join(currentTestingDir, val)
+                            if os.path.isdir(currentValidationDir):
+
+                                filesInDir = os.listdir(
+                                    currentValidationDir
+                                )  # get all files in each directory
+
+                                for i, n in enumerate(filesInDir):
+                                    # when the log has been found, collect the final numbers
+                                    if "trainingScores_log" in n:
+
+                                        log_file = os.path.join(currentValidationDir, n)
+                                        with open(log_file) as f:
+                                            for line in f:
+                                                pass
+                                            final_stats = final_stats + line
+
+            data_string = StringIO(final_stats)
+            data_full = pd.read_csv(data_string, sep=",")
+            del data_full["Epoch"]  # no need for epoch
+            data_full.to_csv(outputFile, index=False)  # save updated data
+
+            # perform deep copy
+            data_loss = data_full.copy()
+            data_dice = data_full.copy()
+
+            cols = [
+                "Train",
+                "Val",
+                "Testing",
+            ]  # set the datasets that need to be plotted
+            for i in cols:
+
+                del data_dice[i + "_Loss"]  # keep only dice
+                del data_loss[i + "_Dice"]  # keep only loss
+
+                data_loss.rename(
+                    columns={i + "_Loss": i}, inplace=True
+                )  # rename the columns
+                data_dice.rename(
+                    columns={i + "_Dice": i}, inplace=True
+                )  # rename the columns
+
+            fig, axes = plt.subplots(
+                nrows=1, ncols=2, constrained_layout=True
+            )  # set plot properties
+
+            bplot = sns.boxplot(
+                data=data_dice, width=0.5, palette="colorblind", ax=axes[0]
+            )  # plot the data
+            bplot.set(ylim=(0, 1))  # set limits for y-axis for proper visualization
+            bplot.set(xlabel="Dataset", ylabel="Dice", title="Dice plot")  # set labels
+            bplot.set_xticklabels(
+                bplot.get_xticklabels(), rotation=15, ha="right"
+            )  # rotate so that everything is visible
+
+            bplot = sns.boxplot(
+                data=data_loss, width=0.5, palette="colorblind", ax=axes[1]
+            )  # plot the data
+            bplot.set(ylim=(0, 1))  # set limits for y-axis for proper visualization
+            bplot.set(xlabel="Dataset", ylabel="Loss", title="Loss plot")  # set labels
+            bplot.set_xticklabels(
+                bplot.get_xticklabels(), rotation=15, ha="right"
+            )  # rotate so that everything is visible
+
+            plt.savefig(outputPlot, dpi=600)
+
+            print("Plots saved successfully.")
 
 
 # main function

--- a/gandlf_collectStats
+++ b/gandlf_collectStats
@@ -76,9 +76,7 @@ def main():
 
             print("Classification task detected, generating accuracy and loss plots.")
 
-            if (
-                combinedPlots
-            ):  # check whether user wants training + validation overlayed plots
+            if combinedPlots:  # check whether user wants training + validation overlayed plots
 
                 df_training = pd.read_csv(trainingLogs)
                 df_validation = pd.read_csv(validationLogs)


### PR DESCRIPTION
Currently, collectStats only successfully generates plots to visualize results for segmentation tasks and has no support for classification tasks. As such, this update allows for the visualization of training/validation accuracy and loss plots for classification tasks.

## Proposed Changes
<!-- Bullet pointed list of changes, please try to keep code changes as small as possible-->
-  Add an argument (`--combinedplots`/`-c`) that specifies whether users would like training/validation plots for visualizing accuracy and loss to be overlayed in 2 plots or displayed separately in 4 plots (only used for classification)
- Detects the type of task (segmentation or classification) determined by the presence of data in the testing logs and generates plots accordingly
- For classification tasks, uses training and validation logs to generate accuracy and loss line plots, overlaying training and validation plots (2 total plots) or keeping them separate (4 total plots) depending on the user's preferences; retains original functionality for segmentation tasks
- Displays an output message upon task detection and a success message upon plot generation

## Checklist

<!-- You do not need to complete all the items by the time you submit the pull request, 
but PRs are more likely to be merged quickly if all the tasks are done. -->

<!-- Replace `[ ]` with `[x]` in all the boxes that apply.
Note that if a box is left unchecked, PR merges will take longer than usual.
-->
- [x] I have read the [`CONTRIBUTING`](https://github.com/CBICA/GaNDLF/blob/master/CONTRIBUTING.md) guide
- [x] My PR is based from the [current GaNDLF master ](https://garygregory.wordpress.com/2016/11/10/how-to-catch-up-my-git-fork-to-master/)
- [x] Non-breaking change (does **not** break existing functionality): provide **as many** details as possible for _any_ breaking change 
- [x] Function/class source code documentation added/updated
- [x] Code has been [blacked](https://github.com/psf/black#usage) for style consistency
- [x] If applicable, version information [has been updated in GANDLF/version.py](https://github.com/CBICA/GaNDLF/blob/master/GANDLF/version.py)
- [x] If adding a git submodule, add to list of exceptions for black styling in [pyproject.toml](https://github.com/CBICA/GaNDLF/blob/master/pyproject.toml) file 
- [x] [Usage documentation](https://github.com/CBICA/GaNDLF/blob/master/docs) has been updated, if appropriate
- [x] [History](https://github.com/CBICA/GaNDLF/blob/master/HISTORY.md) has been updated, if appropriate
- [x] Tests added or modified to [cover the changes](https://app.codecov.io/gh/CBICA/GaNDLF); if coverage is reduced, please give explanation
- [x] If customized dependency installation is required (i.e., a separate `pip install` step is needed for PR to be functional), please ensure it is reflected in all the files that control the CI, namely: [python-test.yml](https://github.com/CBICA/GaNDLF/blob/master/.github/workflows/python-test.yml), and all docker files [[1](https://github.com/CBICA/GaNDLF/blob/master/Dockerfile-CPU),[2](https://github.com/CBICA/GaNDLF/blob/master/Dockerfile-CUDA10.2),[3](https://github.com/CBICA/GaNDLF/blob/master/Dockerfile-CUDA11.3),[4](https://github.com/CBICA/GaNDLF/blob/master/Dockerfile-ROCm)] 
