### PR TITLE
Added option to not pick up pretrained weights for `imagenet_vgg`

### DIFF
--- a/GANDLF/models/imagenet_vgg.py
+++ b/GANDLF/models/imagenet_vgg.py
@@ -53,8 +53,9 @@ class imagenet_vgg11(ModelBase):
         if self.n_dimensions != 2:
             raise ValueError("ImageNet pre-trained models only support 2D images")
 
+        pretrained = parameters["model"].get("pretrained", True)
         self.model = create_torchvision_model(
-            "vgg11", pretrained=True, num_classes=self.n_classes
+            "vgg11", pretrained=pretrained, num_classes=self.n_classes
         )
 
     def forward(self, x):
@@ -70,8 +71,9 @@ class imagenet_vgg11_bn(ModelBase):
         if self.n_dimensions != 2:
             raise ValueError("ImageNet pre-trained models only support 2D images")
 
+        pretrained = parameters["model"].get("pretrained", True)
         self.model = create_torchvision_model(
-            "vgg11_bn", pretrained=True, num_classes=self.n_classes
+            "vgg11_bn", pretrained=pretrained, num_classes=self.n_classes
         )
 
     def forward(self, x):
@@ -87,8 +89,9 @@ class imagenet_vgg13(ModelBase):
         if self.n_dimensions != 2:
             raise ValueError("ImageNet pre-trained models only support 2D images")
 
+        pretrained = parameters["model"].get("pretrained", True)
         self.model = create_torchvision_model(
-            "vgg13", pretrained=True, num_classes=self.n_classes
+            "vgg13", pretrained=pretrained, num_classes=self.n_classes
         )
 
     def forward(self, x):
@@ -104,8 +107,9 @@ class imagenet_vgg13_bn(ModelBase):
         if self.n_dimensions != 2:
             raise ValueError("ImageNet pre-trained models only support 2D images")
 
+        pretrained = parameters["model"].get("pretrained", True)
         self.model = create_torchvision_model(
-            "vgg13_bn", pretrained=True, num_classes=self.n_classes
+            "vgg13_bn", pretrained=pretrained, num_classes=self.n_classes
         )
 
     def forward(self, x):
@@ -121,8 +125,9 @@ class imagenet_vgg16(ModelBase):
         if self.n_dimensions != 2:
             raise ValueError("ImageNet pre-trained models only support 2D images")
 
+        pretrained = parameters["model"].get("pretrained", True)
         self.model = create_torchvision_model(
-            "vgg16", pretrained=True, num_classes=self.n_classes
+            "vgg16", pretrained=pretrained, num_classes=self.n_classes
         )
 
     def forward(self, x):
@@ -138,8 +143,9 @@ class imagenet_vgg16_bn(ModelBase):
         if self.n_dimensions != 2:
             raise ValueError("ImageNet pre-trained models only support 2D images")
 
+        pretrained = parameters["model"].get("pretrained", True)
         self.model = create_torchvision_model(
-            "vgg16_bn", pretrained=True, num_classes=self.n_classes
+            "vgg16_bn", pretrained=pretrained, num_classes=self.n_classes
         )
 
     def forward(self, x):
@@ -155,8 +161,9 @@ class imagenet_vgg19(ModelBase):
         if self.n_dimensions != 2:
             raise ValueError("ImageNet pre-trained models only support 2D images")
 
+        pretrained = parameters["model"].get("pretrained", True)
         self.model = create_torchvision_model(
-            "vgg19", pretrained=True, num_classes=self.n_classes
+            "vgg19", pretrained=pretrained, num_classes=self.n_classes
         )
 
     def forward(self, x):
@@ -172,8 +179,9 @@ class imagenet_vgg19_bn(ModelBase):
         if self.n_dimensions != 2:
             raise ValueError("ImageNet pre-trained models only support 2D images")
 
+        pretrained = parameters["model"].get("pretrained", True)
         self.model = create_torchvision_model(
-            "vgg19_bn", pretrained=True, num_classes=self.n_classes
+            "vgg19_bn", pretrained=pretrained, num_classes=self.n_classes
         )
 
     def forward(self, x):


### PR DESCRIPTION
<!-- Replace ISSUE_NUMBER with the issue that will be auto-linked to close after merging this PR -->
Fixes #N.A.

## Proposed Changes
<!-- Bullet pointed list of changes, please try to keep code changes as small as possible-->
- added option to using not pretrained weights for the imagenet vgg models

## Checklist

<!-- You do not need to complete all the items by the time you submit the pull request, 
but PRs are more likely to be merged quickly if all the tasks are done. -->

<!-- Replace `[ ]` with `[x]` in all the boxes that apply.
Note that if a box is left unchecked, PR merges will take longer than usual.
-->
- [x] I have read the [`CONTRIBUTING`](https://github.com/CBICA/GaNDLF/blob/master/CONTRIBUTING.md) guide
- [x] My PR is based from the [current GaNDLF master ](https://garygregory.wordpress.com/2016/11/10/how-to-catch-up-my-git-fork-to-master/)
- [x] Non-breaking change (does **not** break existing functionality): provide **as many** details as possible for _any_ breaking change 
- [x] Function/class source code documentation added/updated
- [x] Code has been [blacked](https://github.com/psf/black#usage) for style consistency
- [x] If applicable, version information [has been updated in GANDLF/version.py](https://github.com/CBICA/GaNDLF/blob/master/GANDLF/version.py)
- [x] If adding a git submodule, add to list of exceptions for black styling in [pyproject.toml](https://github.com/CBICA/GaNDLF/blob/master/pyproject.toml) file 
- [x] [Usage documentation](https://github.com/CBICA/GaNDLF/blob/master/docs) has been updated, if appropriate
- [x] [History](https://github.com/CBICA/GaNDLF/blob/master/HISTORY.md) has been updated, if appropriate
- [x] Tests added or modified to [cover the changes](https://app.codecov.io/gh/CBICA/GaNDLF); if coverage is reduced, please give explanation
- [x] If customized dependency installation is required (i.e., a separate `pip install` step is needed for PR to be functional), please ensure it is reflected in all the files that control the CI, namely: [python-test.yml](https://github.com/CBICA/GaNDLF/blob/master/.github/workflows/python-test.yml), and all docker files [[1](https://github.com/CBICA/GaNDLF/blob/master/Dockerfile-CPU),[2](https://github.com/CBICA/GaNDLF/blob/master/Dockerfile-CUDA10.2),[3](https://github.com/CBICA/GaNDLF/blob/master/Dockerfile-CUDA11.3),[4](https://github.com/CBICA/GaNDLF/blob/master/Dockerfile-ROCm)] 
